### PR TITLE
Remove dark mode support and theme switching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "framer-motion": "^12.6.2",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
-        "next-themes": "^0.3.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
@@ -4901,14 +4900,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.3.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "framer-motion": "^12.6.2",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
-    "next-themes": "^0.3.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLegislative } from "@/contexts/LegislativeContext";
-import { useTheme } from "@/contexts/ThemeContext";
+
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -25,8 +25,6 @@ import {
   Vote,
   Calendar,
   BarChart3,
-  Moon,
-  Sun,
 } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { getRoleDisplayName } from "@/utils/permissions";
@@ -38,7 +36,7 @@ interface DashboardLayoutProps {
 const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   const { user, logout } = useAuth();
   const { getUnreadNotifications } = useLegislative();
-  const { theme, toggleTheme } = useTheme();
+
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -192,14 +190,7 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
                     <User className="mr-2 h-4 w-4" />
                     Profil
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={toggleTheme}>
-                    {theme === "dark" ? (
-                      <Sun className="mr-2 h-4 w-4" />
-                    ) : (
-                      <Moon className="mr-2 h-4 w-4" />
-                    )}
-                    {theme === "dark" ? "Mode clair" : "Mode sombre"}
-                  </DropdownMenuItem>
+
                   <DropdownMenuItem>
                     <Settings className="mr-2 h-4 w-4" />
                     Paramètres

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -124,15 +124,15 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   const navigationItems = getNavigationItems();
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-gray-50">
       {/* Top Navigation */}
-      <header className="bg-white dark:bg-gray-800 shadow-sm border-b dark:border-gray-700">
+      <header className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
             <div className="flex items-center">
               <div className="flex items-center">
-                <Scale className="h-8 w-8 text-blue-600 dark:text-blue-400" />
-                <span className="ml-3 text-xl font-semibold text-gray-900 dark:text-gray-100">
+                <Scale className="h-8 w-8 text-blue-600" />
+                <span className="ml-3 text-xl font-semibold text-gray-900">
                   Assemblée Législative
                 </span>
               </div>
@@ -172,10 +172,10 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
                       </AvatarFallback>
                     </Avatar>
                     <div className="hidden md:block text-left">
-                      <div className="text-sm font-medium dark:text-gray-100">
+                      <div className="text-sm font-medium">
                         {user?.firstName} {user?.lastName}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                      <div className="text-xs text-gray-500">
                         {getRoleDisplayName(user?.role!)}
                       </div>
                     </div>

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,14 +1,11 @@
-import { useTheme } from "next-themes";
 import { Toaster as Sonner } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="light"
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,17 +1,9 @@
-import React, {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  ReactNode,
-} from "react";
+import React, { createContext, useContext, useEffect, ReactNode } from "react";
 
-type Theme = "light" | "dark";
+type Theme = "light";
 
 interface ThemeContextType {
   theme: Theme;
-  toggleTheme: () => void;
-  setTheme: (theme: Theme) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
@@ -19,35 +11,18 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 export const ThemeProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    const stored = localStorage.getItem("legislativeApp_theme");
-    if (stored && (stored === "light" || stored === "dark")) {
-      return stored as Theme;
-    }
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
-  });
+  const theme: Theme = "light";
 
   useEffect(() => {
     const root = window.document.documentElement;
     root.classList.remove("light", "dark");
     root.classList.add(theme);
-    localStorage.setItem("legislativeApp_theme", theme);
+    // Clean up any existing theme preference
+    localStorage.removeItem("legislativeApp_theme");
   }, [theme]);
 
-  const toggleTheme = () => {
-    setThemeState((prev) => (prev === "light" ? "dark" : "light"));
-  };
-
-  const setTheme = (newTheme: Theme) => {
-    setThemeState(newTheme);
-  };
-
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
-      {children}
-    </ThemeContext.Provider>
+    <ThemeContext.Provider value={{ theme }}>{children}</ThemeContext.Provider>
   );
 };
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -16,10 +16,12 @@ export const ThemeProvider: React.FC<{ children: ReactNode }> = ({
   useEffect(() => {
     const root = window.document.documentElement;
     root.classList.remove("light", "dark");
-    root.classList.add(theme);
+    root.classList.add("light");
     // Clean up any existing theme preference
     localStorage.removeItem("legislativeApp_theme");
-  }, [theme]);
+    // Ensure body has proper background
+    document.body.style.backgroundColor = "white";
+  }, []);
 
   return (
     <ThemeContext.Provider value={{ theme }}>{children}</ThemeContext.Provider>

--- a/src/index.css
+++ b/src/index.css
@@ -50,44 +50,6 @@
 
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
-
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
-  }
 }
 
 @layer base {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -52,13 +52,13 @@ const Login = () => {
     <div className="min-h-screen flex items-center justify-center px-4 relative">
       {/* Background Image */}
       <div
-        className="absolute inset-0 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-900"
+        className="absolute inset-0 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-900 transition-all duration-500"
         style={{
-          backgroundImage: 'url("/palais-du-peuple.jpg")',
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          backgroundRepeat: "no-repeat",
-          backgroundBlendMode: "overlay",
+          backgroundImage:
+            'url("/palais-du-peuple.jpg"), linear-gradient(135deg, #1e3a8a 0%, #1e40af 50%, #1e3a8a 100%)',
+          backgroundSize: "cover, cover",
+          backgroundPosition: "center, center",
+          backgroundRepeat: "no-repeat, no-repeat",
         }}
       ></div>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -49,17 +49,21 @@ const Login = () => {
   ];
 
   return (
-    <div
-      className="min-h-screen flex items-center justify-center px-4 relative"
-      style={{
-        backgroundImage: 'url("/palais-du-peuple.jpg")',
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        backgroundRepeat: "no-repeat",
-      }}
-    >
+    <div className="min-h-screen flex items-center justify-center px-4 relative">
+      {/* Background Image */}
+      <div
+        className="absolute inset-0 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-900"
+        style={{
+          backgroundImage: 'url("/palais-du-peuple.jpg")',
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
+          backgroundBlendMode: "overlay",
+        }}
+      ></div>
+
       {/* Overlay pour améliorer la lisibilité */}
-      <div className="absolute inset-0 bg-black bg-opacity-40"></div>
+      <div className="absolute inset-0 bg-black bg-opacity-30"></div>
       <div className="w-full max-w-md space-y-6 relative z-10">
         <div className="text-center">
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-full flex items-center justify-center mb-4">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -49,36 +49,21 @@ const Login = () => {
   ];
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4 relative">
-      {/* Background Image */}
-      <div
-        className="absolute inset-0 transition-all duration-500"
-        style={{
-          backgroundImage:
-            'url("https://images.unsplash.com/photo-1555599807-3bf4de7a6731?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2000&q=80")',
-          backgroundSize: "cover",
-          backgroundPosition: "center",
-          backgroundRepeat: "no-repeat",
-          backgroundAttachment: "fixed",
-        }}
-      ></div>
-
-      {/* Overlay pour améliorer la lisibilité */}
-      <div className="absolute inset-0 bg-black bg-opacity-30"></div>
-      <div className="w-full max-w-md space-y-6 relative z-10">
+    <div className="min-h-screen flex items-center justify-center bg-white px-4">
+      <div className="w-full max-w-md space-y-6">
         <div className="text-center">
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-full flex items-center justify-center mb-4">
             <Scale className="h-6 w-6 text-white" />
           </div>
-          <h1 className="text-3xl font-bold text-white drop-shadow-lg">
+          <h1 className="text-3xl font-bold text-gray-900">
             Assemblée Législative
           </h1>
-          <p className="text-gray-100 mt-2 drop-shadow-md">
+          <p className="text-gray-600 mt-2">
             Système de gestion du processus législatif
           </p>
         </div>
 
-        <Card className="backdrop-blur-sm bg-white/95 shadow-2xl border-0">
+        <Card>
           <CardHeader>
             <CardTitle>Connexion</CardTitle>
             <CardDescription>
@@ -125,7 +110,7 @@ const Login = () => {
           </CardContent>
         </Card>
 
-        <Card className="backdrop-blur-sm bg-white/95 shadow-2xl border-0">
+        <Card>
           <CardHeader>
             <CardTitle className="text-lg">Comptes de démonstration</CardTitle>
             <CardDescription>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -49,21 +49,31 @@ const Login = () => {
   ];
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white px-4">
-      <div className="w-full max-w-md space-y-6">
+    <div
+      className="min-h-screen flex items-center justify-center px-4 relative"
+      style={{
+        backgroundImage: 'url("/palais-du-peuple.jpg")',
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+      }}
+    >
+      {/* Overlay pour améliorer la lisibilité */}
+      <div className="absolute inset-0 bg-black bg-opacity-40"></div>
+      <div className="w-full max-w-md space-y-6 relative z-10">
         <div className="text-center">
           <div className="mx-auto h-12 w-12 bg-blue-600 rounded-full flex items-center justify-center mb-4">
             <Scale className="h-6 w-6 text-white" />
           </div>
-          <h1 className="text-3xl font-bold text-gray-900">
+          <h1 className="text-3xl font-bold text-white drop-shadow-lg">
             Assemblée Législative
           </h1>
-          <p className="text-gray-600 mt-2">
+          <p className="text-gray-100 mt-2 drop-shadow-md">
             Système de gestion du processus législatif
           </p>
         </div>
 
-        <Card>
+        <Card className="backdrop-blur-sm bg-white/95 shadow-2xl border-0">
           <CardHeader>
             <CardTitle>Connexion</CardTitle>
             <CardDescription>
@@ -110,7 +120,7 @@ const Login = () => {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="backdrop-blur-sm bg-white/95 shadow-2xl border-0">
           <CardHeader>
             <CardTitle className="text-lg">Comptes de démonstration</CardTitle>
             <CardDescription>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -52,13 +52,14 @@ const Login = () => {
     <div className="min-h-screen flex items-center justify-center px-4 relative">
       {/* Background Image */}
       <div
-        className="absolute inset-0 bg-gradient-to-br from-blue-900 via-blue-800 to-blue-900 transition-all duration-500"
+        className="absolute inset-0 transition-all duration-500"
         style={{
           backgroundImage:
-            'url("/palais-du-peuple.jpg"), linear-gradient(135deg, #1e3a8a 0%, #1e40af 50%, #1e3a8a 100%)',
-          backgroundSize: "cover, cover",
-          backgroundPosition: "center, center",
-          backgroundRepeat: "no-repeat, no-repeat",
+            'url("https://images.unsplash.com/photo-1555599807-3bf4de7a6731?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=2000&q=80")',
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundRepeat: "no-repeat",
+          backgroundAttachment: "fixed",
         }}
       ></div>
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -85,10 +85,8 @@ const Profile = () => {
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-            Mon profil
-          </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">
+          <h1 className="text-3xl font-bold text-gray-900">Mon profil</h1>
+          <p className="text-gray-600 mt-1">
             Gérez vos informations personnelles et préférences
           </p>
         </div>
@@ -194,7 +192,7 @@ const Profile = () => {
                     id="role"
                     value={getRoleDisplayName(user.role)}
                     disabled
-                    className="bg-gray-50 dark:bg-gray-800"
+                    className="bg-gray-50"
                   />
                 </div>
 
@@ -319,7 +317,7 @@ const Profile = () => {
             <CardContent className="space-y-4">
               <div className="space-y-2">
                 <p className="text-sm font-medium">ID Utilisateur</p>
-                <code className="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">
+                <code className="text-xs bg-gray-100 px-2 py-1 rounded">
                   {user.id}
                 </code>
               </div>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { useTheme } from "@/contexts/ThemeContext";
+
 import {
   Card,
   CardContent,
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Switch } from "@/components/ui/switch";
+
 import { Separator } from "@/components/ui/separator";
 import {
   User,
@@ -22,8 +22,6 @@ import {
   Users,
   ArrowLeft,
   Settings,
-  Moon,
-  Sun,
   Shield,
   Calendar,
 } from "lucide-react";
@@ -34,7 +32,7 @@ import { fr } from "date-fns/locale";
 
 const Profile = () => {
   const { user, updateUser } = useAuth();
-  const { theme, toggleTheme } = useTheme();
+
   const navigate = useNavigate();
 
   const [isEditing, setIsEditing] = useState(false);
@@ -319,28 +317,6 @@ const Profile = () => {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3">
-                  {theme === "dark" ? (
-                    <Moon className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-                  ) : (
-                    <Sun className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-                  )}
-                  <div>
-                    <p className="text-sm font-medium">Mode sombre</p>
-                    <p className="text-xs text-gray-600 dark:text-gray-400">
-                      Activer le thème sombre
-                    </p>
-                  </div>
-                </div>
-                <Switch
-                  checked={theme === "dark"}
-                  onCheckedChange={toggleTheme}
-                />
-              </div>
-
-              <Separator />
-
               <div className="space-y-2">
                 <p className="text-sm font-medium">ID Utilisateur</p>
                 <code className="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded">

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -66,10 +66,10 @@ const Statistics = () => {
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          <h1 className="text-3xl font-bold text-gray-900">
             Statistiques législatives
           </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">
+          <p className="text-gray-600 mt-1">
             Analyses détaillées de l'activité parlementaire
           </p>
         </div>

--- a/src/pages/bills/BillsManagement.tsx
+++ b/src/pages/bills/BillsManagement.tsx
@@ -114,10 +114,8 @@ const BillsManagement = () => {
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
-            Gestion des lois
-          </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">
+          <h1 className="text-3xl font-bold text-gray-900">Gestion des lois</h1>
+          <p className="text-gray-600 mt-1">
             Supervision et validation des propositions de loi
           </p>
         </div>

--- a/src/pages/plenary/SessionManagement.tsx
+++ b/src/pages/plenary/SessionManagement.tsx
@@ -156,10 +156,10 @@ const SessionManagement = () => {
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          <h1 className="text-3xl font-bold text-gray-900">
             Gestion des sessions
           </h1>
-          <p className="text-gray-600 dark:text-gray-400 mt-1">
+          <p className="text-gray-600 mt-1">
             Programmation et conduite des sessions plénières
           </p>
         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,6 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  darkMode: ["class"],
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",


### PR DESCRIPTION
This pull request removes dark mode functionality from the application:

- Removed `next-themes` dependency from package.json
- Updated ThemeContext to only support light theme, removing toggle and state management
- Removed dark mode CSS variables and classes from index.css
- Updated components to remove dark mode styling:
  - DashboardLayout: Removed theme toggle dropdown and dark mode classes
  - Profile: Removed theme switching UI and dark mode preferences
  - Sonner: Fixed to light theme only
  - Various pages: Removed dark mode text color classes
- Updated Tailwind config to remove dark mode class strategy
- Cleaned up theme-related imports and unused icons (Moon, Sun)

The application now uses a consistent light theme across all components.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3d06080facb54e2e941eed89e4e422bc/pulse-verse)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3d06080facb54e2e941eed89e4e422bc</projectId>-->